### PR TITLE
Run Docker as plain user, not as root

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: lycheeverse/lychee:latest
-      options: --user 0
       env:
         GITHUB_TOKEN: $LYCHEE_GITHUB_TOKEN
 


### PR DESCRIPTION
This was needed because the binary was not in $PATH, and not accessible to plain users.

This has been fixed since and running as root is no longer required.